### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/pkg/certificates/client.go
+++ b/pkg/certificates/client.go
@@ -17,6 +17,11 @@ import (
 
 // CreateClientCertificate creates a new client certificate and p12 file
 func (c *CertificateService) CreateClientCertificate(commonName string, p12Password string) error {
+	// Validate commonName
+	if strings.Contains(commonName, "/") || strings.Contains(commonName, "\\") || strings.Contains(commonName, "..") {
+		return fmt.Errorf("invalid common name: %s", commonName)
+	}
+
 	// Create directory for the certificate
 	certDir := c.storage.GetCertificateDirectory(commonName)
 	if err := os.MkdirAll(certDir, 0755); err != nil {

--- a/pkg/handlers/index.go
+++ b/pkg/handlers/index.go
@@ -84,9 +84,9 @@ func createCertificateHandler(certSvc *certificates.CertificateService, store *s
 		additionalDomains := c.PostForm("additional_domains")
 
 		// Validate input
-		if commonName == "" {
+		if commonName == "" || strings.Contains(commonName, "/") || strings.Contains(commonName, "\\") || strings.Contains(commonName, "..") {
 			c.HTML(http.StatusBadRequest, "index.html", gin.H{
-				"Error": "Common Name is required",
+				"Error": "Invalid Common Name",
 			})
 			return
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/5](https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/5)

To fix the issue, we need to validate and sanitize the `commonName` input before using it to construct file paths. The validation should ensure that the input does not contain any path separators (`/`, `\`) or parent directory references (`..`). Additionally, we can normalize the path and ensure it is within a predefined safe directory.

The best approach is to:
1. Add validation logic in the `createCertificateHandler` function in `pkg/handlers/index.go` to reject invalid `commonName` values early.
2. Optionally, add a secondary validation step in the `CreateClientCertificate` method in `pkg/certificates/client.go` to ensure that the `commonName` is safe before constructing file paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
