### PR TITLE
Potential fix for code scanning alert no. 40: Uncontrolled data used in path expression

### DIFF
--- a/pkg/handlers/index.go
+++ b/pkg/handlers/index.go
@@ -180,10 +180,10 @@ func deleteCertificateHandler(certSvc *certificates.CertificateService, store *s
 	return func(c *gin.Context) {
 		// Get certificate name
 		name := c.PostForm("name")
-		if name == "" {
+		if name == "" || strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
 			c.JSON(http.StatusBadRequest, APIResponse{
 				Success: false,
-				Message: "Certificate name is required",
+				Message: "Invalid certificate name",
 			})
 			return
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/40](https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/40)

To fix the issue, we need to validate the `name` parameter to ensure it does not contain any path traversal sequences (`..`) or path separators (`/` or `\`). This ensures that the constructed paths remain within the intended directory structure. 

1. Add validation logic in the `deleteCertificateHandler` function to reject invalid `name` values before calling `store.DeleteCertificate(name)`.
2. Ensure that the `name` parameter is treated as a single path component and does not allow directory traversal or absolute paths.
3. Return an appropriate error response if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
