### PR TITLE
Potential fix for code scanning alert no. 2: Email content injection

### DIFF
--- a/pkg/handlers/settings.go
+++ b/pkg/handlers/settings.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"regexp"
 	"github.com/Lazarev-Cloud/localca-go/pkg/certificates"
 	"github.com/Lazarev-Cloud/localca-go/pkg/config"
 	"github.com/Lazarev-Cloud/localca-go/pkg/email"
@@ -104,6 +105,16 @@ func testEmailHandler(certSvc *certificates.CertificateService, store *storage.S
 			c.JSON(http.StatusBadRequest, APIResponse{
 				Success: false,
 				Message: "Test email address is required",
+			})
+			return
+		}
+
+		// Validate email format
+		emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+		if matched := regexp.MustCompile(emailRegex).MatchString(testEmail); !matched {
+			c.JSON(http.StatusBadRequest, APIResponse{
+				Success: false,
+				Message: "Invalid email address format",
 			})
 			return
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/2](https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/2)

To fix the issue, we need to validate and sanitize the `testEmail` parameter before using it in the `SendEmail` function. Specifically:
1. Validate that the `testEmail` parameter is a properly formatted email address.
2. Reject or sanitize any input that does not conform to the expected format.
3. Ensure that the `to` parameter in `SendEmail` only contains validated and sanitized data.

We will use a regular expression to validate the email address format. If the validation fails, an appropriate error response will be returned to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
