### PR TITLE
Potential fix for code scanning alert no. 4: Email content injection

### DIFF
--- a/pkg/email/notifications.go
+++ b/pkg/email/notifications.go
@@ -45,14 +45,10 @@ func (e *EmailService) SendEmail(from, to, subject, body string) error {
 	}
 
 	// Format the message
-	message := []byte(
-		fmt.Sprintf("To: %s\r\n"+
-			"From: %s\r\n"+
-			"Subject: %s\r\n"+
-			"MIME-Version: 1.0\r\n"+
-			"Content-Type: text/plain; charset=UTF-8\r\n"+
-			"\r\n"+
-			"%s", to, from, subject, body))
+	message, err := constructEmailMessage(from, to, subject, body)
+	if err != nil {
+		return fmt.Errorf("failed to construct email message: %w", err)
+	}
 
 	// Set authentication
 	auth := smtp.PlainAuth("", e.SMTPUser, e.SMTPPassword, e.SMTPServer)

--- a/pkg/handlers/settings.go
+++ b/pkg/handlers/settings.go
@@ -147,7 +147,18 @@ func testEmailHandler(certSvc *certificates.CertificateService, store *storage.S
 		// Send test email
 		subject := "LocalCA Test Email"
 		body := "This is a test email from LocalCA."
-		if err := emailSvc.SendEmail(emailFrom, testEmail, subject, body); err != nil {
+		
+		// Sanitize the testEmail input
+		sanitizedEmail := sanitizeEmail(testEmail)
+		if sanitizedEmail == "" {
+			c.JSON(http.StatusBadRequest, APIResponse{
+				Success: false,
+				Message: "Invalid or unsafe email address",
+			})
+			return
+		}
+		
+		if err := emailSvc.SendEmail(emailFrom, sanitizedEmail, subject, body); err != nil {
 			log.Printf("Failed to send test email: %v", err)
 			c.JSON(http.StatusInternalServerError, APIResponse{
 				Success: false,


### PR DESCRIPTION
Potential fix for [https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/4](https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/4)

To fix the issue, we need to sanitize the `testEmail` input before using it in the `SendEmail` method. This can be achieved by ensuring that the `to` parameter is properly escaped or sanitized to prevent injection attacks. Additionally, we should use a trusted library or method to handle email construction and ensure that all inputs are safely encoded.

1. Add a sanitization step for the `testEmail` variable in `pkg/handlers/settings.go` before passing it to the `SendEmail` method.
2. Use a library or utility function to safely construct the email headers and body in `pkg/email/notifications.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
