### PR TITLE
Potential fix for code scanning alert no. 6: Email content injection

### DIFF
--- a/pkg/handlers/settings.go
+++ b/pkg/handlers/settings.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/mail"
 	"strconv"
 
 	"github.com/Lazarev-Cloud/localca-go/pkg/certificates"
@@ -104,6 +105,16 @@ func testEmailHandler(certSvc certificates.CertificateServiceInterface, store *s
 			c.JSON(http.StatusBadRequest, APIResponse{
 				Success: false,
 				Message: "Test email address is required",
+			})
+			return
+		}
+
+		// Validate email format
+		_, err := mail.ParseAddress(testEmail)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, APIResponse{
+				Success: false,
+				Message: "Invalid email address format",
 			})
 			return
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/6](https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/6)

To fix the issue, we need to sanitize and validate the user-controlled input (`testEmail`) before using it in the email message. Specifically:
1. Validate that `testEmail` is a properly formatted email address.
2. Sanitize the `testEmail` input to ensure it does not contain malicious content or unexpected characters.

The best approach is to use a well-known library for email validation, such as the `net/mail` package in Go, which provides robust email address parsing and validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
