### PR TITLE
Potential fix for code scanning alert no. 45: Uncontrolled data used in path expression

### DIFF
--- a/pkg/handlers/index.go
+++ b/pkg/handlers/index.go
@@ -188,6 +188,15 @@ func deleteCertificateHandler(certSvc certificates.CertificateServiceInterface, 
 			return
 		}
 
+		// Validate certificate name
+		if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+			c.JSON(http.StatusBadRequest, APIResponse{
+				Success: false,
+				Message: "Invalid certificate name",
+			})
+			return
+		}
+
 		// Delete certificate
 		if err := store.DeleteCertificate(name); err != nil {
 			log.Printf("Failed to delete certificate: %v", err)


### PR DESCRIPTION
Potential fix for [https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/45](https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/45)

To fix the issue, we need to validate the `name` parameter to ensure it does not contain any path traversal sequences (`../`) or invalid characters. Since `name` is expected to be a single directory name, we can enforce this by:
1. Checking that `name` does not contain any path separators (`/` or `\`) or `..` sequences.
2. Optionally, using a whitelist of allowed characters (e.g., alphanumeric and underscores) to further restrict the input.

The validation should be added in the `deleteCertificateHandler` function in `pkg/handlers/index.go` before calling `store.DeleteCertificate(name)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
