### PR TITLE
Potential fix for code scanning alert no. 6: Email content injection

### DIFF
--- a/pkg/email/notifications.go
+++ b/pkg/email/notifications.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+// sanitizeInput sanitizes input to prevent injection attacks
+func sanitizeInput(input string) string {
+	// Replace CRLF characters to prevent header injection
+	return strings.ReplaceAll(strings.ReplaceAll(input, "\r", ""), "\n", "")
+}
+
 // EmailService handles email notifications
 type EmailService struct {
 	SMTPServer   string
@@ -45,6 +51,11 @@ func (e *EmailService) SendEmail(from, to, subject, body string) error {
 	}
 
 	// Format the message
+	// Sanitize inputs
+	safeTo := sanitizeInput(to)
+	safeSubject := sanitizeInput(subject)
+	safeBody := sanitizeInput(body)
+
 	message := []byte(
 		fmt.Sprintf("To: %s\r\n"+
 			"From: %s\r\n"+
@@ -52,7 +63,7 @@ func (e *EmailService) SendEmail(from, to, subject, body string) error {
 			"MIME-Version: 1.0\r\n"+
 			"Content-Type: text/plain; charset=UTF-8\r\n"+
 			"\r\n"+
-			"%s", to, from, subject, body))
+			"%s", safeTo, from, safeSubject, safeBody))
 
 	// Set authentication
 	auth := smtp.PlainAuth("", e.SMTPUser, e.SMTPPassword, e.SMTPServer)

--- a/pkg/handlers/settings.go
+++ b/pkg/handlers/settings.go
@@ -147,7 +147,8 @@ func testEmailHandler(certSvc certificates.CertificateServiceInterface, store *s
 		// Send test email
 		subject := "LocalCA Test Email"
 		body := "This is a test email from LocalCA."
-		if err := emailSvc.SendEmail(emailFrom, testEmail, subject, body); err != nil {
+		safeTestEmail := sanitizeInput(testEmail)
+		if err := emailSvc.SendEmail(emailFrom, safeTestEmail, subject, body); err != nil {
 			log.Printf("Failed to send test email: %v", err)
 			c.JSON(http.StatusInternalServerError, APIResponse{
 				Success: false,


### PR DESCRIPTION
Potential fix for [https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/6](https://github.com/Lazarev-Cloud/localca-go/security/code-scanning/6)

To fix the issue, we need to sanitize the `testEmail` input before using it in the email message. This can be achieved by ensuring that the `to` parameter in the `SendEmail` method is properly escaped or sanitized to prevent injection attacks. Additionally, we should validate the `subject` and `body` parameters to ensure they do not contain malicious content.

1. Modify the `SendEmail` method in `pkg/email/notifications.go` to sanitize the `to`, `subject`, and `body` parameters before constructing the email message.
2. Use a library or utility function to escape or sanitize the input to prevent injection attacks.
3. Ensure that the `testEmail` input is sanitized before being passed to the `SendEmail` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
